### PR TITLE
Version 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 We follow Semantic Version.
 
+## Version 1.0.1
+
+### Misc
+
+- Locked version of `urllib3` to `<2` as workaround for https://github.com/docker/docker-py/issues/3113
+- Locked version of `requests` to `<2.29`  as workaround for https://github.com/docker/docker-py/issues/3113
 
 ## Version 1.0.0
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -746,14 +746,14 @@ pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_ve
 
 [[package]]
 name = "identify"
-version = "2.5.23"
+version = "2.5.24"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.23-py2.py3-none-any.whl", hash = "sha256:17d9351c028a781456965e781ed2a435755cac655df1ebd930f7186b54399312"},
-    {file = "identify-2.5.23.tar.gz", hash = "sha256:50b01b9d5f73c6b53e5fa2caf9f543d3e657a9d0bbdeb203ebb8d45960ba7433"},
+    {file = "identify-2.5.24-py2.py3-none-any.whl", hash = "sha256:986dbfb38b1140e763e413e6feb44cd731faf72d1909543178aa79b0e258265d"},
+    {file = "identify-2.5.24.tar.gz", hash = "sha256:0aac67d5b4812498056d28a9a512a483f5085cc28640b02b258a59dac34301d4"},
 ]
 
 [package.extras]
@@ -1410,14 +1410,14 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.29.0"
+version = "2.28.2"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.7, <4"
 files = [
-    {file = "requests-2.29.0-py3-none-any.whl", hash = "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b"},
-    {file = "requests-2.29.0.tar.gz", hash = "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"},
+    {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
+    {file = "requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"},
 ]
 
 [package.dependencies]
@@ -1857,4 +1857,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9f0bcbbfb2da7951158dfb129b89b818db17e6ddba260441b0ecc9cf7b72a5b2"
+content-hash = "cd629fa130618baf841941e5cd5d3c72c4f6fc31d4ab6b1f73e77fa9dba7a095"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docker-image-size-limit"
-version = "1.0.0"
+version = "1.0.1"
 description = ""
 license = "MIT"
 authors = [
@@ -39,6 +39,8 @@ python = "^3.8"
 
 docker = ">=3.7,<7.0"
 humanfriendly = ">=4.18,<11.0"
+urllib3 = "<2"
+requests = "<2.29"
 
 [tool.poetry.group.test.dependencies]
 pytest-cov = "^4.0"


### PR DESCRIPTION
- Version 1.0.1 release
- Lock "requests" and "urllib3" versions to fix incompatibility with docker-py 6.0.1
- Fixes #261