### PR TITLE
Upgrade docker-image-size-limit version to 1.0.1 on Dockerfile used by the Github Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ LABEL maintainer="sobolevn@wemake.services"
 LABEL vendor="wemake.services"
 
 # Our own tool:
-ENV DISL_VERSION='1.0.0'
+ENV DISL_VERSION='1.0.1'
 
 RUN apk add --no-cache bash docker
 RUN pip3 install "docker-image-size-limit==$DISL_VERSION"


### PR DESCRIPTION
Sorry, on #262 I forgot to also update the `disl` version on the docker container used by Action Github.
Closes #261 and complements #262
