### PR TITLE
Add the --current-size and --exit-zero to optionally show current docker image size and avoid stop the CI even if exceed max_size and max-layers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -52,7 +52,6 @@ jobs:
         poetry run flake8 .
         poetry run mypy .
         poetry run pytest
-        poetry check
         poetry run pip check
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,4 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 We follow Semantic Version.
 
+## Version 2.1.0
+
+### Features
+
+- Adds `--current-size` flag to show the current size of the docker image.
+- Adds `--exit-zero` flag to force the exit code to be 0 even if there are errors.
+- Adds `__main__.py` entrypoint to be able to run it via `python -m docker_image_size_limit`
 
 ## Version 2.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="wemake.services"
 
 # Our own tool:
-ENV DISL_VERSION='2.0.0'
+ENV DISL_VERSION='2.1.0'
 
 RUN apk add --no-cache bash docker
 RUN pip3 install "docker-image-size-limit==$DISL_VERSION"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,42 @@ $ disl your-image-name:label 300MiB --max-layers=5
 # ok!
 ```
 
+Add `--current-size` flag to show the current size your image:
+
+```bash
+$ disl your-image-name:label 300MiB --current-size
+your-image-name:label size is 414.4 MiB
+your-image-name:label exceeds 300MiB limit by 114.4 MiB
+```
+
+
+Add `--exit-zero` flag to force the exit code to be 0 even if there are errors:
+
+```bash
+$ disl your-image-name:label 300MiB --exit-zero
+your-image-name:label exceeds 300MiB limit by 114.4 MiB
+
+$ echo $?
+0
+```
+
+You can combine all flags together:
+
+```bash
+$ disl your-image-name:label 300MiB --max-layers=5 --current-size --exit-zero
+your-image-name:label size is 414.4 MiB
+your-image-name:label exceeds 300MiB limit by 114.4 MiB
+your-image-name:label exceeds 5 maximum layers by 2
+```
+
+Run `disl` as a module:
+
+```bash
+$ python -m docker_image_size_limit your-image-name:label 300MiB
+your-image-name:label exceeds 300MiB limit by 114.4 MiB
+```
+
+
 
 ## Options
 
@@ -84,6 +120,10 @@ You can also use this check as a [GitHub Action](https://github.com/marketplace/
   with:
     image: "$YOUR_IMAGE_NAME"
     size: "$YOUR_SIZE_LIMIT"
+    # optional fields:
+    max_layers: 5
+    show_current_size: false
+    exit_zero: false
 ```
 
 Here's [an example](https://github.com/wemake-services/docker-image-size-limit/actions?query=workflow%3Adisl).
@@ -105,6 +145,9 @@ Then you can use it like so:
 docker run -v /var/run/docker.sock:/var/run/docker.sock --rm \
   -e INPUT_IMAGE="$YOUR_IMAGE_NAME" \
   -e INPUT_SIZE="$YOUR_SIZE_LIMIT" \
+  -e INPUT_MAX_LAYERS="$YOUR_MAX_LAYERS" \
+  -e INPUT_SHOW_CURRENT_SIZE="true" \
+  -e INPUT_EXIT_ZERO="true" \
   wemakeservices/docker-image-size-limit
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 # This is a definition file for a Github Action.
-# See: https://help.github.com/en/articles/creating-a-docker-container-action
+# See: https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-docker-container-action
 
 # We also define metadata here:
-# See: https://help.github.com/en/articles/metadata-syntax-for-github-actions
+# See: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions
 
 name: 'docker-image-size-limit'
 description: 'Runs docker-image-size-limit as a GitHub Action'
@@ -21,6 +21,14 @@ inputs:
     description: 'The maximum number of layers in the image'
     required: false
     default: -1
+  show_current_size:
+    description: 'Show the current size of the image'
+    required: false
+    default: 'false'
+  exit_zero:
+    description: 'Do not fail the action even if docker image size/layers exceed size and max_layers'
+    required: false
+    default: 'false'
 outputs:
   size:
     description: 'The output of docker-image-size-limit run'
@@ -32,3 +40,5 @@ runs:
     - ${{ inputs.image }}
     - ${{ inputs.size }}
     - ${{ inputs.layers }}
+    - ${{ inputs.show_current_size }}
+    - ${{ inputs.exit_zero }}

--- a/docker_image_size_limit/__main__.py
+++ b/docker_image_size_limit/__main__.py
@@ -1,0 +1,12 @@
+import sys
+from os.path import basename
+
+from docker_image_size_limit import main
+
+if __name__ == '__main__':  # pragma: no cover
+    interpreter_binary_name = basename(sys.executable)
+    main(
+        prog_name='{0} -m docker_image_size_limit'.format(
+            interpreter_binary_name,
+        ),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docker-image-size-limit"
-version = "2.0.0"
+version = "2.1.0"
 description = ""
 license = "MIT"
 authors = [

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,19 +1,42 @@
 #!/bin/bash
 
-# Default values:
+# Passed args from GitHub Actions:
+: "${INPUT_IMAGE:=$1}"  # Required
+: "${INPUT_SIZE:=$2}"  # Required
+: "${INPUT_MAX_LAYERS:=$3}"  # Optional
+: "${INPUT_SHOW_CURRENT_SIZE:=$4}"  # Optional
+: "${INPUT_EXIT_ZERO:=$5}"  # Optional
+
+# Default values, needed because `Dockerfile` can be used directly:
+# These values must match ones in `action.yml`!
 : "${INPUT_MAX_LAYERS:=-1}"
+: "${INPUT_SHOW_CURRENT_SIZE:=false}"
+: "${INPUT_EXIT_ZERO:=false}"
 
 # Diagnostic output:
 echo "Using image: $INPUT_IMAGE"
 echo "Size limit: $INPUT_SIZE"
 echo "Max layers: $INPUT_MAX_LAYERS"
+echo "Show Current Size: $INPUT_SHOW_CURRENT_SIZE"
+echo "Exit Zero: $INPUT_EXIT_ZERO"
 echo 'disl --version:'
 disl --version
 echo '================================='
 echo
 
+SHOW_CURRENT_SIZE_FLAG=''
+if [ "$INPUT_SHOW_CURRENT_SIZE" = 'true' ]; then
+  SHOW_CURRENT_SIZE_FLAG='--current-size'
+fi
+
+EXIT_ZERO_FLAG=''
+if [ "$INPUT_EXIT_ZERO" = 'true' ]; then
+  EXIT_ZERO_FLAG='--exit-zero'
+fi
+
+
 # Runs disl:
-output=$(disl "$INPUT_IMAGE" "$INPUT_SIZE" --max-layers="$INPUT_MAX_LAYERS")
+output=$(disl "$INPUT_IMAGE" "$INPUT_SIZE" --max-layers="$INPUT_MAX_LAYERS" "$SHOW_CURRENT_SIZE_FLAG" "$EXIT_ZERO_FLAG")
 status="$?"
 
 # Sets the output variable for Github Action API:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ ignore = D100, D104, D401, W504, RST303, RST304, DAR103, DAR203
 
 per-file-ignores =
   # There are `assert`s in tests:
-  tests/*.py: WPS442, S101, S404, S603, S607
+  tests/*.py: WPS442, S101, S404, S603, S607, WPS226
 
 
 [isort]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 import subprocess
+import sys
+from os.path import basename
 
 
 def test_disl_exceeds_limit(image_name: str) -> None:
@@ -58,3 +60,92 @@ def test_disl_max_layers(image_name: str) -> None:
     assert process.returncode == 1
     assert 'maximum layers by' in output
     assert image_name in output
+
+
+def test_disl_current_size(image_name: str) -> None:
+    """Runs `disl` command with --current-size flag."""
+    process = subprocess.Popen(
+        [
+            'disl',
+            image_name,
+            '1 kb',
+            '--current-size',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        encoding='utf8',
+    )
+    output, _ = process.communicate()
+
+    assert process.returncode == 1
+    assert 'current size is' in output
+    assert image_name in output
+
+
+def test_disl_exit_zero(image_name: str) -> None:
+    """Runs `disl` command with --exit-zero flag."""
+    process = subprocess.Popen(
+        [
+            'disl',
+            image_name,
+            '1 kb',
+            '--current-size',
+            '--exit-zero',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        encoding='utf8',
+    )
+    output, _ = process.communicate()
+
+    assert process.returncode == 0
+    assert 'current size is' in output
+    assert image_name in output
+
+
+def test_docker_image_size_limit_as_module(image_name: str) -> None:
+    """Runs `disl` command with --exit-zero flag."""
+    interpreter_binary_name = basename(sys.executable)
+    process = subprocess.Popen(
+        [
+            '{0}'.format(interpreter_binary_name),
+            '-m',
+            'docker_image_size_limit',
+            image_name,
+            '1 kb',
+            '--current-size',
+            '--exit-zero',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        encoding='utf8',
+    )
+    output, _ = process.communicate()
+
+    assert process.returncode == 0
+    assert 'current size is' in output
+    assert image_name in output
+
+
+def test_docker_image_size_limit_as_module_help_flag(image_name: str) -> None:  # noqa: WPS118,E501
+    """Runs `disl` command via it python module."""
+    interpreter_binary_name = basename(sys.executable)
+    process = subprocess.Popen(
+        [
+            '{0}'.format(interpreter_binary_name),
+            '-m',
+            'docker_image_size_limit',
+            '--help',
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        encoding='utf8',
+    )
+    output, _ = process.communicate()
+
+    assert process.returncode == 0
+    assert 'docker_image_size_limit' in output


### PR DESCRIPTION
- Add the new `--current-size` to display the current size of the docker image. Maybe partially fix #224
- Add the new `--exit-zero` to Exit with 0 even if docker image size/layers exceed `max_size` and `max-layers`
- Add the the `__main__.py` entrypoint to be able execute via module, that it `python -m docker_image_size_limit`
- Use `files` argument instead of `file` argument in the `codecov` github action since it deprecate the `file` argument in favor of `files`
- Increase version to `2.1.0`


It Maybe introduce a breaking change since the `_check_image` function now return 3 values instead of 2